### PR TITLE
Implement marketplace listing, asset purchase, player stat tracking, and read-only views

### DIFF
--- a/contracts/sBTC-Thornecyst.clar
+++ b/contracts/sBTC-Thornecyst.clar
@@ -120,3 +120,118 @@
               transferable: (get transferable asset) })
         (ok true)))  ;; Changed to return (ok true)
 
+
+;; Mint single asset
+(define-public (mint-asset (metadata-uri (string-utf8 256)) (transferable bool))
+    (let
+        ((asset-id (+ (var-get asset-counter) u1)))
+        (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (asserts! (validate-metadata-uri metadata-uri) err-invalid-input)
+        (map-set assets
+            { asset-id: asset-id }
+            { owner: tx-sender,
+              metadata-uri: metadata-uri,
+              transferable: transferable })
+        (var-set asset-counter asset-id)
+        (ok asset-id)))
+
+;; Transfer asset ownership
+(define-public (transfer-asset (asset-id uint) (recipient principal))
+    (begin
+        (asserts! (<= asset-id (var-get asset-counter)) err-invalid-input)
+        (let ((asset (try! (get-asset-checked asset-id))))
+            (asserts! (and
+                    (is-eq (get owner asset) tx-sender)
+                    (get transferable asset)
+                    (not (is-eq recipient tx-sender)))  ;; Prevent self-transfers
+                err-not-authorized)
+            (map-set assets
+                { asset-id: asset-id }
+                { owner: recipient,
+                  metadata-uri: (get metadata-uri asset),
+                  transferable: (get transferable asset) })
+            (ok true))))
+
+;; List asset for sale with enhanced marketplace listing
+(define-public (list-asset-for-sale (asset-id uint) (price uint))
+    (begin
+        (asserts! (<= asset-id (var-get asset-counter)) err-invalid-input)
+        (let ((asset (try! (get-asset-checked asset-id))))
+            (asserts! (and 
+                    (is-eq (get owner asset) tx-sender)
+                    (> price u0)
+                    (get transferable asset))  ;; Ensure asset is transferable
+                err-invalid-price)
+            (map-set marketplace-listings
+                { asset-id: asset-id }
+                { seller: tx-sender, 
+                  price: price, 
+                  listed-at: stacks-block-height })
+            (ok true))))
+
+;; Purchase listed asset with enhanced marketplace mechanics
+(define-public (purchase-asset (asset-id uint))
+    (begin
+        (asserts! (<= asset-id (var-get asset-counter)) err-invalid-input)
+        (let
+            ((asset (try! (get-asset-checked asset-id)))
+             (listing (unwrap! (map-get? marketplace-listings { asset-id: asset-id }) err-not-found)))
+            (asserts! (and
+                    (not (is-eq (get seller listing) tx-sender))
+                    (get transferable asset))
+                err-not-authorized)
+            (try! (stx-transfer? (get price listing) tx-sender (get seller listing)))
+            (map-set assets
+                { asset-id: asset-id }
+                { owner: tx-sender,
+                  metadata-uri: (get metadata-uri asset),
+                  transferable: (get transferable asset) })
+            (map-delete marketplace-listings { asset-id: asset-id })
+            (ok true))))
+
+;; Remove asset from marketplace listing
+(define-public (delist-asset (asset-id uint))
+    (begin
+        ;; Validate asset-id is within the range of minted assets
+        (asserts! (<= asset-id (var-get asset-counter)) err-invalid-input)
+
+        ;; Try to get the listing, return error if not found
+        (let ((listing (unwrap! (map-get? marketplace-listings { asset-id: asset-id }) err-not-found)))
+            ;; Ensure only the seller can delist
+            (asserts! (is-eq tx-sender (get seller listing)) err-not-authorized)
+
+            ;; Delete the marketplace listing
+            (map-delete marketplace-listings { asset-id: asset-id })
+
+            ;; Return success
+            (ok true))))
+
+;; Update player stats with validation
+(define-public (update-player-stats (experience uint) (level uint))
+    (begin
+        (asserts! (<= experience max-experience) err-invalid-input)
+        (asserts! (<= level max-level) err-invalid-input)
+        (map-set player-stats
+            { player: tx-sender }
+            { experience: experience, level: level })
+        (ok true)))
+
+;; Read-only Functions
+
+;; Get asset details
+(define-read-only (get-asset-details (asset-id uint))
+    (if (<= asset-id (var-get asset-counter))
+        (map-get? assets { asset-id: asset-id })
+        none))
+
+;; Get marketplace listing details
+(define-read-only (get-marketplace-listing (asset-id uint))
+    (map-get? marketplace-listings { asset-id: asset-id }))
+
+;; Get player stats
+(define-read-only (get-player-stats (player principal))
+    (map-get? player-stats { player: player }))
+
+;; Get total assets minted
+(define-read-only (get-total-assets)
+    (var-get asset-counter))


### PR DESCRIPTION

###  **Pull Request: Gamin Platform – Marketplace, Player Stats, and Read-only Views**

#### Overview:

This PR completes the core functionalities of the **Gamin Gaming Platform**, enabling asset trading, player stat tracking, and convenient read-only data access.

#### Features Added:

---

### 🎨 Asset Management

* **`mint-asset`**: Allows the contract owner to mint a single asset with metadata and transferability.
* **`transfer-asset`**: Enables secure transfer of asset ownership with proper permission checks.

---

### 🛒 Marketplace Mechanics

* **`list-asset-for-sale`**: Asset owners can list transferable assets for sale at a set price.
* **`purchase-asset`**: Buyers can purchase assets by transferring STX to the seller. Ownership is updated and the listing is removed.
* **`delist-asset`**: Asset owners can remove their listings from the marketplace.

---

### 🎮 Player Statistics

* **`update-player-stats`**: Allows players to update their experience and level with validation (max level 100, max experience 10,000).

---

### 🔍 Read-Only Queries

* **`get-asset-details`**: Fetch metadata, owner, and transferability of a specific asset.
* **`get-marketplace-listing`**: View details of an asset currently listed for sale.
* **`get-player-stats`**: Retrieve a player’s experience and level.
* **`get-total-assets`**: Returns the number of assets minted to date.

---

### 🔐 Validations & Security

* Asset ID bounds enforced for all mutable actions
* Marketplace actions restricted to legitimate sellers and buyers
* Self-transfers and self-purchases explicitly disallowed
* Player stat inputs bounded to defined maximums

---